### PR TITLE
Implement watch mechanism for all resources

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -1077,3 +1077,39 @@ func isRole(group, version, kind string) bool {
 func isNetworkPolicy(group, version, kind string) bool {
 	return group == "networking.k8s.io" && version == "v1" && kind == "NetworkPolicy"
 }
+
+func WatchResource(clientset *kubernetes.Clientset, group, version, kind, name, namespace string) (<-chan watch.Event, error) {
+    // Create a channel to publish events
+    eventChannel := make(chan watch.Event)
+
+    // Define a context
+    ctx, cancel := context.WithCancel(context.Background())
+
+    // Create a dynamic client for the specified resource
+    dynamicClient, err := dynamic.NewForConfig(clientset.RESTConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    resource := schema.GroupVersionResource{Group: group, Version: version, Resource: kind}
+
+    // Start the watch
+    watch, err := dynamicClient.Resource(resource).Namespace(namespace).Watch(ctx, metav1.ListOptions{
+        FieldSelector: "metadata.name=" + name,
+    })
+    if err != nil {
+        cancel()
+        return nil, err
+    }
+
+    // Goroutine to handle watch events
+    go func() {
+        defer close(eventChannel)
+        defer cancel()
+        for event := range watch.ResultChan() {
+            eventChannel <- event
+        }
+    }()
+
+    return eventChannel, nil
+}


### PR DESCRIPTION
closes #523

## 📑 Description
Created a method on the [k8s client](https://github.com/cyclops-ui/cyclops/blob/90f2d765e14babd942940909efde73813033ab90/cyclops-ctrl/internal/cluster/k8sclient/client.go) called WatchResource that will accept and the group, version, kind, name and namespace and return a channel that publishes all events about that particular resource.

## ✅ Checks
- [x] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
